### PR TITLE
Bukkit event

### DIFF
--- a/1.10.2/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.10.2/src/main/java/net/dries007/mclink/MCLink.java
@@ -4,8 +4,10 @@
 
 package net.dries007.mclink;
 
+import com.google.common.collect.ImmutableCollection;
 import com.mojang.authlib.GameProfile;
 import net.dries007.mclink.api.APIException;
+import net.dries007.mclink.api.Authentication;
 import net.dries007.mclink.api.Constants;
 import net.dries007.mclink.binding.FormatCode;
 import net.dries007.mclink.binding.IConfig;
@@ -104,7 +106,7 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void authCompleteAsync(IPlayer player, String msg)
+    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
     {
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());

--- a/1.10.2/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.10.2/src/main/java/net/dries007/mclink/MCLink.java
@@ -108,6 +108,8 @@ public class MCLink extends MCLinkCommon
     @Override
     protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
     {
+        // null authentications means "kick"
+        if (authentications != null) return;
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());
             //noinspection ConstantConditions

--- a/1.10.2/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.10.2/src/main/java/net/dries007/mclink/MCLink.java
@@ -104,7 +104,7 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void kickAsync(IPlayer player, String msg)
+    protected void authCompleteAsync(IPlayer player, String msg)
     {
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());

--- a/1.10.2/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.10.2/src/main/java/net/dries007/mclink/MCLink.java
@@ -106,10 +106,10 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
+    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications, Marker authresult)
     {
-        // null authentications means "kick"
-        if (authentications != null) return;
+        // Don't kick players unless authresult was one of the DENIED_* values
+        if (authresult == Marker.ALLOWED) return;
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());
             //noinspection ConstantConditions

--- a/1.12.2/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.12.2/src/main/java/net/dries007/mclink/MCLink.java
@@ -96,10 +96,10 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
+    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications, Marker authresult)
     {
-        // null authentications means "kick"
-        if (authentications != null) return;
+        // Don't kick players unless authresult was one of the DENIED_* values
+        if (authresult == Marker.ALLOWED) return;
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());
             //noinspection ConstantConditions

--- a/1.12.2/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.12.2/src/main/java/net/dries007/mclink/MCLink.java
@@ -94,7 +94,7 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void kickAsync(IPlayer player, String msg)
+    protected void authCompleteAsync(IPlayer player, String msg)
     {
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());

--- a/1.12.2/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.12.2/src/main/java/net/dries007/mclink/MCLink.java
@@ -4,8 +4,10 @@
 
 package net.dries007.mclink;
 
+import com.google.common.collect.ImmutableCollection;
 import com.mojang.authlib.GameProfile;
 import net.dries007.mclink.api.APIException;
+import net.dries007.mclink.api.Authentication;
 import net.dries007.mclink.api.Constants;
 import net.dries007.mclink.binding.FormatCode;
 import net.dries007.mclink.binding.IConfig;
@@ -94,7 +96,7 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void authCompleteAsync(IPlayer player, String msg)
+    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
     {
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());

--- a/1.12.2/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.12.2/src/main/java/net/dries007/mclink/MCLink.java
@@ -98,6 +98,8 @@ public class MCLink extends MCLinkCommon
     @Override
     protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
     {
+        // null authentications means "kick"
+        if (authentications != null) return;
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());
             //noinspection ConstantConditions

--- a/1.12/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.12/src/main/java/net/dries007/mclink/MCLink.java
@@ -105,6 +105,8 @@ public class MCLink extends MCLinkCommon
     @Override
     protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
     {
+        // null authentications means "kick"
+        if (authentications != null) return;
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());
             //noinspection ConstantConditions

--- a/1.12/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.12/src/main/java/net/dries007/mclink/MCLink.java
@@ -4,8 +4,10 @@
 
 package net.dries007.mclink;
 
+import com.google.common.collect.ImmutableCollection;
 import com.mojang.authlib.GameProfile;
 import net.dries007.mclink.api.APIException;
+import net.dries007.mclink.api.Authentication;
 import net.dries007.mclink.api.Constants;
 import net.dries007.mclink.binding.FormatCode;
 import net.dries007.mclink.binding.IConfig;
@@ -101,7 +103,7 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void authCompleteAsync(IPlayer player, String msg)
+    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
     {
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());

--- a/1.12/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.12/src/main/java/net/dries007/mclink/MCLink.java
@@ -101,7 +101,7 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void kickAsync(IPlayer player, String msg)
+    protected void authCompleteAsync(IPlayer player, String msg)
     {
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());

--- a/1.12/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.12/src/main/java/net/dries007/mclink/MCLink.java
@@ -103,10 +103,10 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
+    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications, Marker authresult)
     {
-        // null authentications means "kick"
-        if (authentications != null) return;
+        // Don't kick players unless authresult was one of the DENIED_* values
+        if (authresult == Marker.ALLOWED) return;
         server.addScheduledTask(() -> {
             EntityPlayerMP p = server.getPlayerList().getPlayerByUUID(player.getUuid());
             //noinspection ConstantConditions

--- a/1.7.10/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.7.10/src/main/java/net/dries007/mclink/MCLink.java
@@ -142,7 +142,7 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void kickAsync(IPlayer player, String msg)
+    protected void authCompleteAsync(IPlayer player, String msg)
     {
         // 1.7.10 doesn't have threading, so use server tick even to sync.
         TO_KICK.put(player.getName(), msg);

--- a/1.7.10/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.7.10/src/main/java/net/dries007/mclink/MCLink.java
@@ -146,6 +146,8 @@ public class MCLink extends MCLinkCommon
     @Override
     protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
     {
+        // null authentications means "kick"
+        if (authentications != null) return;
         // 1.7.10 doesn't have threading, so use server tick even to sync.
         TO_KICK.put(player.getName(), msg);
     }

--- a/1.7.10/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.7.10/src/main/java/net/dries007/mclink/MCLink.java
@@ -5,6 +5,7 @@
 package net.dries007.mclink;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableCollection;
 import com.mojang.authlib.GameProfile;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
@@ -17,6 +18,7 @@ import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.common.network.FMLNetworkEvent;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import net.dries007.mclink.api.APIException;
+import net.dries007.mclink.api.Authentication;
 import net.dries007.mclink.api.Constants;
 import net.dries007.mclink.binding.FormatCode;
 import net.dries007.mclink.binding.IConfig;
@@ -142,7 +144,7 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void authCompleteAsync(IPlayer player, String msg)
+    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
     {
         // 1.7.10 doesn't have threading, so use server tick even to sync.
         TO_KICK.put(player.getName(), msg);

--- a/1.7.10/src/main/java/net/dries007/mclink/MCLink.java
+++ b/1.7.10/src/main/java/net/dries007/mclink/MCLink.java
@@ -144,10 +144,10 @@ public class MCLink extends MCLinkCommon
     }
 
     @Override
-    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
+    protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications, Marker authresult)
     {
-        // null authentications means "kick"
-        if (authentications != null) return;
+        // Don't kick players unless authresult was one of the DENIED_* values
+        if (authresult == Marker.ALLOWED) return;
         // 1.7.10 doesn't have threading, so use server tick even to sync.
         TO_KICK.put(player.getName(), msg);
     }

--- a/Bukkit/src/main/java/net/dries007/mclink/MCLink.java
+++ b/Bukkit/src/main/java/net/dries007/mclink/MCLink.java
@@ -41,7 +41,7 @@ public final class MCLink extends JavaPlugin implements Listener
         }
 
         @Override
-        protected void kickAsync(IPlayer player, String msg)
+        protected void authCompleteAsync(IPlayer player, String msg)
         {
             Bukkit.getScheduler().runTask(MCLink.this, () -> Bukkit.getPlayer(player.getUuid()).kickPlayer(msg));
         }

--- a/Bukkit/src/main/java/net/dries007/mclink/MCLink.java
+++ b/Bukkit/src/main/java/net/dries007/mclink/MCLink.java
@@ -44,13 +44,10 @@ public final class MCLink extends JavaPlugin implements Listener
         }
 
         @Override
-        protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
+        protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications, Marker authresult)
         {
-            if (authentications == null) {
-                // null authentications means "kick"
-                Bukkit.getScheduler().runTask(MCLink.this, () -> Bukkit.getPlayer(player.getUuid()).kickPlayer(msg));
-            } else {
-                // Authentication returned something, now schedule a synchronous Event for Bukkit plugins to handle
+            if (authresult == Marker.ALLOWED) {
+                // Authentication succeeded, now schedule a synchronous Event for Bukkit plugins to handle
                 new BukkitRunnable() {
                     @Override
                     public void run() {
@@ -63,6 +60,9 @@ public final class MCLink extends JavaPlugin implements Listener
                         }
                     }
                 }.runTask(MCLink.this);
+            } else {
+                // authresult was DENIED_*, kick the player
+                Bukkit.getScheduler().runTask(MCLink.this, () -> Bukkit.getPlayer(player.getUuid()).kickPlayer(msg));
             }
         }
 

--- a/Bukkit/src/main/java/net/dries007/mclink/MCLink.java
+++ b/Bukkit/src/main/java/net/dries007/mclink/MCLink.java
@@ -5,6 +5,8 @@
 package net.dries007.mclink;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableCollection;
+import net.dries007.mclink.api.Authentication;
 import net.dries007.mclink.binding.FormatCode;
 import net.dries007.mclink.binding.IPlayer;
 import net.dries007.mclink.common.JavaLogger;
@@ -17,6 +19,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
@@ -41,9 +44,21 @@ public final class MCLink extends JavaPlugin implements Listener
         }
 
         @Override
-        protected void authCompleteAsync(IPlayer player, String msg)
+        protected void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications)
         {
-            Bukkit.getScheduler().runTask(MCLink.this, () -> Bukkit.getPlayer(player.getUuid()).kickPlayer(msg));
+            if (authentications == null) {
+                // null authentications means "kick"
+                Bukkit.getScheduler().runTask(MCLink.this, () -> Bukkit.getPlayer(player.getUuid()).kickPlayer(msg));
+            } else {
+                // Authentication returned something, now schedule a synchronous Event for Bukkit plugins to handle
+                new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        // Call the event with a Bukkit player and the list of authentications
+                        Bukkit.getServer().getPluginManager().callEvent(new MCLinkAuthEvent(Bukkit.getPlayer(player.getUuid()), authentications));
+                    }
+                }.runTask(MCLink.this);
+            }
         }
 
         @Nullable

--- a/Bukkit/src/main/java/net/dries007/mclink/MCLink.java
+++ b/Bukkit/src/main/java/net/dries007/mclink/MCLink.java
@@ -55,7 +55,12 @@ public final class MCLink extends JavaPlugin implements Listener
                     @Override
                     public void run() {
                         // Call the event with a Bukkit player and the list of authentications
-                        Bukkit.getServer().getPluginManager().callEvent(new MCLinkAuthEvent(Bukkit.getPlayer(player.getUuid()), authentications));
+                        org.bukkit.entity.Player bukkitPlayer = Bukkit.getPlayer(player.getUuid());
+                        if (bukkitPlayer != null) {
+                            Bukkit.getServer().getPluginManager().callEvent(new MCLinkAuthEvent(bukkitPlayer, authentications));
+                        } else {
+                            getLogger().info(String.format("Player %s went away before MCLink event could be triggered",player.getName()));
+                        }
                     }
                 }.runTask(MCLink.this);
             }

--- a/Bukkit/src/main/java/net/dries007/mclink/MCLinkAuthEvent.java
+++ b/Bukkit/src/main/java/net/dries007/mclink/MCLinkAuthEvent.java
@@ -1,0 +1,38 @@
+package net.dries007.mclink;
+
+/*
+ * Copyright (c) 2018 Dries007 & Brian Ronald. All rights reserved
+ */
+
+import com.google.common.collect.ImmutableCollection;
+import net.dries007.mclink.api.Authentication;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class MCLinkAuthEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private ImmutableCollection<Authentication> authentication;
+    private org.bukkit.entity.Player player;
+
+    public MCLinkAuthEvent(org.bukkit.entity.Player player, ImmutableCollection<Authentication> authentication) {
+        this.player = player;
+        this.authentication = authentication;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public org.bukkit.entity.Player getPlayer() {
+        return player;
+    }
+
+    public ImmutableCollection<Authentication> getAuthentication() {
+        return authentication;
+    }
+}

--- a/src/main/java/net/dries007/mclink/binding/IConfig.java
+++ b/src/main/java/net/dries007/mclink/binding/IConfig.java
@@ -39,6 +39,8 @@ public interface IConfig
      */
     boolean setClosed(boolean closed);
 
+    boolean isFreeToJoin();
+
     boolean isShowStatus();
 
     @NotNull

--- a/src/main/java/net/dries007/mclink/common/CommonConfig.java
+++ b/src/main/java/net/dries007/mclink/common/CommonConfig.java
@@ -124,7 +124,7 @@ public abstract class CommonConfig implements IConfig
         ImmutableMap<String, Service> services = API.getServices();
         Table<String, String, List<String>> tokenConfig = HashBasedTable.create();
 
-        String kickMessage = getString("kickMessage", "This is an MCLink protected server. Link your accounts via " + Constants.BASE_URL + " and make sure you are subscribed to the right people.", "The message used to kickAsync players. Make sure to include instructions on how to get on!");
+        String kickMessage = getString("kickMessage", "This is an MCLink protected server. Link your accounts via " + Constants.BASE_URL + " and make sure you are subscribed to the right people.", "The message used to kick players if they've been blocked. Make sure to include instructions on how to get on!");
         String errorMessage = getString("errorMessage", "MCLink could not verify your status. Please contact a server admin.", "The message people get when an error happens while MCLink checks their ID.");
         String closedMessage = getString("closedMessage", "The server is currently closed for the public.", "The message people get when the server is closed.");
         boolean showStatus = getBoolean("showStatus", true, "Show important status messages to level 2+ OP players when they log in.");

--- a/src/main/java/net/dries007/mclink/common/CommonConfig.java
+++ b/src/main/java/net/dries007/mclink/common/CommonConfig.java
@@ -47,6 +47,7 @@ public abstract class CommonConfig implements IConfig
 
     private boolean showStatus;
     private boolean closed;
+    private boolean freeToJoin;
 
     public static ImmutableList<String> splitArgumentString(String line)
     {
@@ -105,6 +106,11 @@ public abstract class CommonConfig implements IConfig
     }
 
     @Override
+    public boolean isFreeToJoin() {
+        return freeToJoin;
+    }
+
+    @Override
     public boolean isShowStatus()
     {
         return showStatus;
@@ -123,6 +129,7 @@ public abstract class CommonConfig implements IConfig
         String closedMessage = getString("closedMessage", "The server is currently closed for the public.", "The message people get when the server is closed.");
         boolean showStatus = getBoolean("showStatus", true, "Show important status messages to level 2+ OP players when they log in.");
         boolean closed = getBoolean("closed", false, "Use the ingame command /mclink to update this. Keeps track of if the server is closed.");
+        boolean freeToJoin = getBoolean("freeToJoin", false, "The server is free to join");
         int timeout = getInt("timeout", 30, 0, 300, "Timeout for the API requests in seconds. Keep this high enough to avoid players being kicked while actually being authorized. 0 = infinite timeout") * 1000;
 
         setGlobalCommentServices("All service options are put here.\n" +
@@ -174,6 +181,7 @@ public abstract class CommonConfig implements IConfig
         this.errorMessage = errorMessage;
         this.closedMessage = closedMessage;
         this.showStatus = showStatus;
+        this.freeToJoin = freeToJoin;
 
         if (this.closed != closed)
         {

--- a/src/main/java/net/dries007/mclink/common/MCLinkCommon.java
+++ b/src/main/java/net/dries007/mclink/common/MCLinkCommon.java
@@ -41,7 +41,7 @@ public abstract class MCLinkCommon implements IMinecraft
     private Status latestStatus;
     private String branding;
 
-    protected abstract void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications);
+    protected abstract void authCompleteAsync(IPlayer player, String msg, UUID name, ImmutableCollection<Authentication> authentications, Marker authresult);
 
     @Nullable
     protected abstract String nameFromUUID(UUID uuid);
@@ -81,14 +81,13 @@ public abstract class MCLinkCommon implements IMinecraft
             case IN_PROGRESS:
                 break;
             case DENIED_NO_AUTH:
-                // null authentications means "kick"
-                authCompleteAsync(player, config.getKickMessage(), player.getUuid(), null);
+                authCompleteAsync(player, config.getKickMessage(), player.getUuid(), null, Marker.DENIED_NO_AUTH);
                 return;
             case DENIED_ERROR:
-                authCompleteAsync(player, config.getErrorMessage(), player.getUuid(), null);
+                authCompleteAsync(player, config.getErrorMessage(), player.getUuid(), null, Marker.DENIED_ERROR);
                 return;
             case DENIED_CLOSED:
-                authCompleteAsync(player, config.getClosedMessage(), player.getUuid(), null);
+                authCompleteAsync(player, config.getClosedMessage(), player.getUuid(), null, Marker.DENIED_CLOSED);
                 return;
         }
         if (sendStatus && latestStatus != null && config.isShowStatus())
@@ -257,7 +256,7 @@ public abstract class MCLinkCommon implements IMinecraft
                 {
                     UUID_STATUS_MAP.remove(player.getUuid()); // login event already past, so we don't need this anymore.
                     // null authentications means "kick"
-                    authCompleteAsync(player, config.getKickMessage(), player.getUuid(), null);
+                    authCompleteAsync(player, config.getKickMessage(), player.getUuid(), null, Marker.DENIED_NO_AUTH);
                 }
             }
             else
@@ -271,7 +270,7 @@ public abstract class MCLinkCommon implements IMinecraft
                 }
                 logger.info("Player {0} was authorized by: {1}", player, auths);
                 // send the authentications to the mod in question
-                authCompleteAsync(player, null, player.getUuid(), auth);
+                authCompleteAsync(player, null, player.getUuid(), auth, Marker.ALLOWED);
                 if (UUID_STATUS_MAP.put(player.getUuid(), Marker.ALLOWED) == null) // was already removed by login
                 {
                     UUID_STATUS_MAP.remove(player.getUuid()); // login event already passed, so we don't need this anymore.
@@ -287,7 +286,7 @@ public abstract class MCLinkCommon implements IMinecraft
             {
                 UUID_STATUS_MAP.remove(player.getUuid()); // login event already past, so we don't need this anymore.
                 // null authentications means "kick"
-                authCompleteAsync(player, config.getErrorMessage(), player.getUuid(), null);
+                authCompleteAsync(player, config.getErrorMessage(), player.getUuid(), null, Marker.DENIED_ERROR);
             }
         }
     }

--- a/src/main/java/net/dries007/mclink/common/MCLinkCommon.java
+++ b/src/main/java/net/dries007/mclink/common/MCLinkCommon.java
@@ -196,6 +196,10 @@ public abstract class MCLinkCommon implements IMinecraft
         {
             logger.info("Player {0} was authorized because they are on the OP list.", player);
             UUID_STATUS_MAP.put(player.getUuid(), Marker.ALLOWED);
+            // Want to check status anyway, so we can maybe fire off an Event
+            logger.info("Player {0} authorization is being checked anyway...", player);
+            // Set free to true to disable kicking
+            runner.accept(() -> check(player, true));
             return;
         }
 
@@ -219,6 +223,10 @@ public abstract class MCLinkCommon implements IMinecraft
         {
             logger.info("Player {0} was authorized because they are on the whitelist.", player);
             UUID_STATUS_MAP.put(player.getUuid(), Marker.ALLOWED);
+            // Want to check status anyway, so we can maybe fire off an Event
+            logger.info("Player {0} authorization is being checked anyway...", player);
+            // Set free to true to disable kicking
+            runner.accept(() -> check(player, true));
             return;
         }
 

--- a/src/main/java/net/dries007/mclink/common/MCLinkCommon.java
+++ b/src/main/java/net/dries007/mclink/common/MCLinkCommon.java
@@ -205,6 +205,12 @@ public abstract class MCLinkCommon implements IMinecraft
             return;
         }
 
+        if (config.isFreeToJoin()) {
+            logger.info("Player {0} was authorized because the server is allowing all players", player);
+            UUID_STATUS_MAP.put(player.getUuid(), Marker.ALLOWED);
+            return;
+        }
+
         if (whitelisted) // not cached
         {
             logger.info("Player {0} was authorized because they are on the whitelist.", player);

--- a/src/main/java/net/dries007/mclink/common/MCLinkCommon.java
+++ b/src/main/java/net/dries007/mclink/common/MCLinkCommon.java
@@ -41,7 +41,7 @@ public abstract class MCLinkCommon implements IMinecraft
     private Status latestStatus;
     private String branding;
 
-    protected abstract void kickAsync(IPlayer player, String msg);
+    protected abstract void authCompleteAsync(IPlayer player, String msg);
 
     @Nullable
     protected abstract String nameFromUUID(UUID uuid);
@@ -81,13 +81,13 @@ public abstract class MCLinkCommon implements IMinecraft
             case IN_PROGRESS:
                 break;
             case DENIED_NO_AUTH:
-                kickAsync(player, config.getKickMessage());
+                authCompleteAsync(player, config.getKickMessage());
                 return;
             case DENIED_ERROR:
-                kickAsync(player, config.getErrorMessage());
+                authCompleteAsync(player, config.getErrorMessage());
                 return;
             case DENIED_CLOSED:
-                kickAsync(player, config.getClosedMessage());
+                authCompleteAsync(player, config.getClosedMessage());
                 return;
         }
         if (sendStatus && latestStatus != null && config.isShowStatus())
@@ -243,7 +243,7 @@ public abstract class MCLinkCommon implements IMinecraft
                 if (UUID_STATUS_MAP.put(player.getUuid(), Marker.DENIED_NO_AUTH) == null) // was already removed by login
                 {
                     UUID_STATUS_MAP.remove(player.getUuid()); // login event already past, so we don't need this anymore.
-                    kickAsync(player, config.getKickMessage());
+                    authCompleteAsync(player, config.getKickMessage());
                 }
             }
             else
@@ -270,7 +270,7 @@ public abstract class MCLinkCommon implements IMinecraft
             if (UUID_STATUS_MAP.put(player.getUuid(), Marker.DENIED_ERROR) == null) // was already removed by login
             {
                 UUID_STATUS_MAP.remove(player.getUuid()); // login event already past, so we don't need this anymore.
-                kickAsync(player, config.getErrorMessage());
+                authCompleteAsync(player, config.getErrorMessage());
             }
         }
     }


### PR DESCRIPTION
The idea was to make this plugin useful on a Bukkit server which allows all players to join, but provides coloured names and custom chat prefixes to players who support the server through Patreon or Twitch. This was achieved by implementing two additional features:

1. A config option, `freeToJoin`, which defaults to `false` (the current behaviour). When set to `true` the plugin will no longer disconnect players who cannot be associated with the given service keys.
2. A custom Bukkit event, `MCLinkAuthEvent`, which extends `org.bukkit.event.Event`. This event can be handled by one or more custom Bukkit plugins, which are solely responsible for acting on the information provided. MCLink itself has no payload beyond the built-in disconnect option.

The first feature extends to all builds; the three Forge builds and the Bukkit plugin. The second feature is only implemented in the Bukkit plugin. That said, any means of passing information to other Forge mods can be implemented in the Forge-specific implementations of `authCompleteAsync()`.